### PR TITLE
백준 17298번 오큰수

### DIFF
--- a/byeongjoo/백준 17298 오큰수.py
+++ b/byeongjoo/백준 17298 오큰수.py
@@ -1,0 +1,13 @@
+n = int(input())
+arr = list(map(int, input().split()))
+stack= []
+ans = [-1] * n
+
+for i in range(n):
+
+    while stack and (stack[-1][0] < arr[i]):
+        val, idx = stack.pop()
+        ans[idx] = arr[i]
+    stack.append((arr[i], i))
+
+print(*ans)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 17298번 오큰수](https://www.acmicpc.net/problem/17298)

### 💡 문제에서 사용된 알고리즘

스택

---

### 📜 코드 설명

 설명을 읽기 전 이 문제는 본인의 힘으로만 푼 것이 아닌 몇 일 전 답지를 한 번 확인하고 오늘 풀었습니다.

 크기가 N인 수열 A = A1, A2, ..., AN이 있다. 수열의 각 원소 Ai에 대해서 오큰수 NGE(i)를 구하려고 한다. Ai의 오큰수는 오른쪽에 있으면서 Ai보다 큰 수 중에서 가장 왼쪽에 있는 수를 의미한다. 그러한 수가 없는 경우에 오큰수는 -1이다.
예를 들어, A = [3, 5, 2, 7]인 경우 NGE(1) = 5, NGE(2) = 7, NGE(3) = 7, NGE(4) = -1이다. A = [9, 5, 4, 8]인 경우에는 NGE(1) = -1, NGE(2) = 8, NGE(3) = 8, NGE(4) = -1이다.

 일단 문제의 시간복잡도를 생각해보자. 시간제한은 1억 번 연산이 가능하지만, n 은 100만, A는 100만 까지 데이터 크기가 가능하다. 한마디로 일단 O(n^2) 이 되는 브루트포스 방식으로는 불가능하다. 그러므로 O(n)이거나 O(logN) 이 될 수 있는 풀이로 해야한다. 트리로 풀 수 있는지는 전혀 모르겠지만, 본인은 O(n)을 고려해 스택으로 풀었다.

 본인은 처음 정답을 표기할 ans 리스트를 n 크기로 -1을 깔아두었다. 그러함으로써 첫번째 인덱스가 값이 데이터배열에서 가장 높은 점과 마지막 인덱스의 값이 무조건 -1 이여야 한다는 점에서 -1로 바로 표기할 수 있다.

 먼저 스택은 arr의 데이터 값와 그 데이터의 인덱스를 저장했다.
 반복문 조건으론 스택에 데이터가 존재하는지, 스택의 top 데이터 값이 현재 arr의 데이터보다 작은지를 비교해 조건이 성립한다면 반복문을 사용할 수 있도록 했다. 그 후, 데이터가 존재한다면 현재 스택의 top을 pop 하여 데이터 값과 데이터 인덱스를 변수 (val, idx) 로 받아와 정답배열인 ans의 인덱스에 top의 인덱스를 넣어주고 큰 데이터 값을 넣어주었다.
이 위 설명이 while을 쓴 가장 큰 이유인데, 예제 입력에서 3 5 2 7 인 경우 현재 비교대상이 7까지 갔을 때 (arr[3]), stack 안에 들어간 데이터는 ( (5 , 1) , (2, 2)) 일 것이다. 스택의 top은 arr[4]인 7보다 데이터값이 계속 작을 테니 인덱스 1 과 2는 둘 다 7로 대입될 것이다.
그러면 정답인 [5 7 7 -1]이 뚝딱하고 나온다.

본인이 이 문제를 풀면서 알게된 점
1. 연산 과정에서만 다 처리할 생각을 하지 말자. 처음 초기값 설정할 때부터 -1을 다 넣는다는 센스.
2. 스택을 꼭 데이터 값만 저장한다는 생각을 버리자. 사실 이 문제와 비슷한 문제가 있다. (백준 2493번 탑 : https://www.acmicpc.net/problem/2493)
3. 파이썬에선 print(*리스트) 를 하면 ' 1 2 3 4 ' 형태로 값을 보여줄 수 있다.
---
