### PR TITLE
백준 7569번 토마토

### DIFF
--- a/byeongjoo/백준 7569 토마토.py
+++ b/byeongjoo/백준 7569 토마토.py
@@ -1,0 +1,61 @@
+"""
+입력
+M, N, H : 가로 세로 높이
+M은 열
+N은 행
+H은 3차원 시작 idx
+
+1 -> 익은 토마토
+0 -> 익지 않은 토마토
+-1 -> 토마토 없음.
+
+N개의 줄이 H번 반복함.
+"""
+
+from collections import deque
+import sys
+
+input = sys.stdin.readline
+
+m, n, h = map(int, input().split())
+board = [[list(map(int, input().split())) for _ in range(n)] for _ in range(h)]
+dist = [[[0 for i in range(m)] for i in range(n)] for i in range(h)]
+
+dx = [1,-1,0,0,0,0]
+dy = [0,0,1,-1,0,0]
+dz = [0,0,0,0,1,-1]
+
+queue = deque()
+
+for i in range(h):
+    for j in range(n):
+        for k in range(m):
+            if board[i][j][k] == 1:
+                queue.append((i, j, k))
+            if board[i][j][k] == 0:
+                dist[i][j][k] = -1
+
+while queue:
+    x, y, z = queue.popleft()
+    for direction in range(6):
+        nx = x + dx[direction]
+        ny = y + dy[direction]
+        nz = z + dz[direction]
+        if 0 > nx or nx >= h or 0 > ny or ny >= n or 0 > nz or nz >= m :
+            continue
+        if dist[nx][ny][nz] >= 0:
+            continue
+        dist[nx][ny][nz] = dist[x][y][z] + 1
+        queue.append((nx, ny, nz))
+
+ans = 0
+for i in range(h):
+    for j in range(n):
+        for k in range(m):
+            if dist[i][j][k] == -1:
+                print(-1)
+                exit(0)
+
+            ans = max(ans , dist[i][j][k])
+
+print(ans)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 7569번 토마토] : (https://www.acmicpc.net/problem/7569)

---

### 💡 문제에서 사용된 알고리즘

BFS

---

### 📜 코드 설명

3차원 배열 BFS 문제.

3차원 배열이기에 dx, dy, dz 로 동서남북을 지정해주었다.

board 리스트는 입력 보드크기이며, dist 리스트는 내가 움직일 거리를 나타내기 위한 리스트이다.
BFS를 돌리기 전에 BFS를 시작할 시작점을 먼저 queue에 삽입을 했다. 익은 토마토를 시작점으로 잡아 보드에서 1인 지점들을 queue에 삽입을 하였고, 익지 않은 토마토는 거리로 잡을 수 있기에 dist에 -1로 잡아두었다. 
그 후 단순한 bfs를 하고, 거리움직임을 가산하기 위해서 다음 dist배열은 현재 dist배열보다 1을 가산하여 대입해주었다. bfs 조건문으로 들어간 첫 if문은 nx, ny, nz의 범위를 넘어서면 continue 해준 것이고,두 번째 if문은 내가 움직이려는 범위는 처음에 깔아두었던 -1이기에 만약 0보다 크다면 이미 누군가 움직였던 칸이기에 continue로 뛰어넘게 하였다.

마지막으로 dist 리스트 중 -1이 아직 남아있다면 bfs 중 남은 칸이 있다는 것이기에 -1을 출력하였고, 최대크기는 max로 계속 비교해주었다.



---
