### PR TITLE
백준 1259 팰린드롬수

### DIFF
--- a/hyeonwoo/백준 1259 팰린드롬수.py
+++ b/hyeonwoo/백준 1259 팰린드롬수.py
@@ -1,0 +1,94 @@
+import sys
+
+
+def reverse_number(n):
+    return str(n)[::-1]
+
+
+def get_even_front_number(num):
+    result = ""
+
+    num = str(num)
+    num_len = len(num)
+
+    result += num[: num_len // 2]
+
+    return result
+
+
+def get_even_back_number(num):
+    result = ""
+
+    num = str(num)
+    num_len = len(num)
+
+    result += num[num_len // 2 :]
+
+    return result
+
+
+def get_odd_front_number(num):
+    result = ""
+
+    num = str(num)
+    num_len = len(num)
+
+    result += num[: (num_len - 1) // 2]
+
+    return result
+
+
+def get_odd_back_number(num):
+    result = ""
+
+    num = str(num)
+    num_len = len(num)
+
+    result += num[(num_len + 1) // 2 :]
+
+    return result
+
+
+def is_odd_digit(num):
+    return len(str(num)) % 2 == 1
+
+
+def is_even_digit(num):
+    return len(str(num)) % 2 == 0
+
+
+def is_palindrome(num):
+    result = 0
+
+    if num < 10:
+        result = True
+
+    elif is_odd_digit(num):
+        if get_odd_front_number(num) == reverse_number(get_odd_back_number(num)):
+            result = True
+
+        else:
+            result = False
+
+    elif is_even_digit(num):
+        if get_even_front_number(num) == reverse_number(get_even_back_number(num)):
+            result = True
+
+        else:
+            result = False
+
+    return result
+
+
+input = sys.stdin.readline
+
+while True:
+    num = int(input())
+
+    if num == 0:
+        break
+
+    if is_palindrome(num):
+        print("yes")
+    else:
+        print("no")


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1259 팰린드롬수](https://www.acmicpc.net/problem/1259)

---

### 💡 문제에서 사용된 알고리즘

- 구현
- 문자열

---

### 📜 코드 설명

- 입력 받은 수를 앞, 뒤 절반으로 나누어 앞 절반 부분과 뒤 절반 부분이 대칭인지 비교하였다.
- `10 미만의 수`는 무조건 팰린드롬으로 간주했다.

---
