### PR TITLE
백준 4179번 불

### DIFF
--- a/byeongjoo/백준 4179 불.py
+++ b/byeongjoo/백준 4179 불.py
@@ -1,0 +1,78 @@
+"""
+R : 행
+C : 열
+
+#: 벽
+.: 지나갈 수 있는 공간
+J: 지훈이의 미로에서의 초기위치 (지나갈 수 있는 공간)
+F: 불이 난 공간
+"""
+from collections import deque
+import sys
+
+input = sys.stdin.readline
+
+r, c = map(int,input().split())
+board = []
+
+dx = [0,0,1,-1]
+dy = [1,-1,0,0]
+
+# 지훈이 거리
+dist1 = [[0] * c for _ in range(r)]
+q1 = deque()
+# 불 거리
+dist2 = [[0] * c for _ in range(r)]
+q2 = deque()
+
+for _ in range(r):
+    board.append(list(char for char in input().rstrip()))
+
+for i in range(r):
+    for j in range(c):
+        if board[i][j] == "J":
+            q1.append((i,j))
+            dist1[i][j] = 1
+        if board[i][j] == "F":
+            q2.append((i,j))
+            dist2[i][j] = 1
+
+# 불 bfs
+# 불의 이동거리를 먼저 구한 후 지훈이의 이동범위를 구해야함.
+while q2:
+    x, y = q2.popleft()
+    for direction in range(4):
+        nx = x + dx[direction]
+        ny = y + dy[direction]
+
+        if nx < 0 or nx >= r or ny < 0 or ny >= c:
+            continue
+
+        if dist2[nx][ny] != 0 or board[nx][ny] == "#":
+            continue
+
+        dist2[nx][ny] = dist2[x][y] + 1
+        q2.append((nx, ny))
+
+
+# 지훈이 bfs
+while q1:
+    x, y = q1.popleft()
+    for direction in range(4):
+        nx = x + dx[direction]
+        ny = y + dy[direction]
+
+        if nx < 0 or nx >= r or ny < 0 or ny >= c:
+            print(dist1[x][y])
+            exit(0)
+
+        if dist1[nx][ny] != 0 or board[nx][ny] == "#":
+            continue
+
+        if dist2[nx][ny] != 0 and dist2[nx][ny] <= dist1[x][y]+1 :#불이 이동했는데 불의 이동시간이 지훈이의 이동시간보다 작거나 같다면 지훈이는 움직일 수 없음.
+            continue                                              #또한 불이 움직이지 않은거리는 무조건 지훈이 이동시간보다 값이 낮을테니 조건문에 잡아줘야함.
+
+        dist1[nx][ny] = dist1[x][y] + 1
+        q1.append((nx, ny))
+
+print("IMPOSSIBLE")


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 4179번 불] (https://www.acmicpc.net/problem/4179)

---

### 💡 문제에서 사용된 알고리즘

BFS

---

### 📜 코드 설명

 지훈이와 불 둘 다 수평, 수직 방향으로 1칸씩 이동할 수 있으므로 BFS 로 풀기로 하였다.
 지훈, 불 둘 다 이동거리(dist) 리스트와 큐를 따로 만들어주어서 둘 다 BFS가 가능하도록 하였다.
 지훈, 불 둘의 초기값을 각각 큐에 삽입을 하였으며, dist 리스트에다가도 초기 위치를 1로 잡아두어 bfs가 자기위치로 뒤돌아가는 것을 막아두었다.
 
이제 지훈이와 불을 bfs 해야한다.
본인은 불을 먼저 bfs를 돌린 후, 지훈이 bfs를 돌리기로 하였다.
 불 bfs는 기본적인 bfs 처리를 해주었다.
 지훈이도 기본적인 bfs 를 처리 해주었지만, 조건문에서 불 bfs와 차이가 있다는 점을 알 수 있다.

 첫 번째 조건문은 bfs에서 흔히 하는 index가 out range되는 것을 건너뛰기하는 조건이다. 하지만 이 문제 설명 중 지훈이가 불을 피해 밖으로 피신한 거리값을 출력하는 것이기에 이 조건문이 바로 정상 출력을 할 수 있는 곳이다.✨ 정상 출력이 됬다면 프로그램을 종료시켜야 하기에 exit(0) 을 사용해주었다.

 두 번째 조건문은 일반적인 bfs 거리 꼬임 방지 및 다음 이동방향이 벽에 부딪혔다면 건너뛰는 조건문이다.
 
 세 번째 조건문이 개인적으로 가장 어려웠는데, 불이 이동했는데 불의 이동시간이 지훈이의 이동시간보다 작거나 같다면 지훈이는 움직일 수 없으며, 또한 불이 움직이지 않은거리는 무조건 지훈이 이동시간보다 값이 낮을테니 조건문에 잡아줘야한다는 것이다.✨

 두 개의 bfs 가 만약 정상적으로 돌았다는 것이라면 이미 지훈이는 화상을 입었으니 IMPOSSIBLE을 출력해주어야한다.

---
