### PR TITLE
백준 1697번 숨바꼭질

### DIFF
--- a/byeongjoo/백준 1697 숨바꼭질.py
+++ b/byeongjoo/백준 1697 숨바꼭질.py
@@ -1,0 +1,33 @@
+"""
+
+수빈이 : N
+동생 : K
+
+수빈이 이동 방법 : X-1, X+1, 2*X
+
+"""
+from collections import deque
+
+n, k = map(int, input().split())
+
+dist = [(-1)] * 100002
+
+dist[n] = 0 # 초기값 설정
+q = deque()
+q.append(n)
+
+while dist[k] == -1:
+    x = q.popleft()
+    for i in (x-1, x+1, 2*x):
+        nx = i
+
+        if nx < 0 or nx >100000:
+            continue
+
+        if dist[nx] != -1:
+            continue
+
+        dist[nx] = dist[x] + 1
+        q.append(nx)
+
+print(dist[k])


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 1697번 숨바꼭질] (https://www.acmicpc.net/problem/1697)

---

### 💡 문제에서 사용된 알고리즘

BFS

---

### 📜 코드 설명

1차원 배열로 풀어보는 BFS.

솔직히 BFS 문제집이 아니였다면 BFS인지 몰랐을 것 같다.

수빈이(n) 가 동생(k) 의 위치까지 가는 순간 숨바꼭질이 끝나는 문제이다.

초기 설정으로 board 배열은 필요없고, 거리값만 계산할 dist 배열만 있으면 된다.
BFS 에서 거리 문제 같은 경우 , 몇 가지 조건이 있겠지만 기본적으로 초기지점을 잡는 곳을 0으로 둔다. (움직임이 없으면 거리량이 0 일 수 밖에 없다.) 그러하기에 본인은 dist 배열을 -1로 100002개의 요소로 채워넣었다. (2개 정도는 out range를 막기 위한 방지이다.)
이제 수빈이의 위치를 dist 배열에 삽입하자. (dist[n] = 0). 그 후 queue를 이용하여 수빈이의 초기 위치를 queue에 삽입한다.

이제 while을 돌릴건데, 본인은 bfs에서 while 조건식으로 'queue가 다 빌 때까지' 로 고정관념적으로 생각했는데, 이 문제에선 dist[k] == -1 까지다. 이유는 동생의 위치까지 이동값이 생겨 dist[k]의 값이 변했다는 것은 수빈이와 동생이 만났다는 것을 의미한다.
그 후 dx, dy 가 아닌 for i in (x-1, x+1, x*2) 로 푼다. range-based-for 형식으로 풀면 x-1, x+1, x*2 세 개 다 접근이 가능하기에 조건문을 길게 쓸 필요가 사라진다.

그 후 전형적인 범위 벗어날 때 continue, 이동거리값이 꼬일 때 continue를 해주고 , dist[nx] = dist[x] +1 형식으로 해주며, queue에 nx의 값을 push 해준다.

그후 bfs가 끝났다면 , 거리값이 동생의 위치까지 들어갔다는 말이니 dist[k]를 출력해주면 끝이다.

---
