### PR TITLE
백준 1929 소수 구하기

### DIFF
--- a/byeongjoo/백준 1929 소수 구하기.py
+++ b/byeongjoo/백준 1929 소수 구하기.py
@@ -1,0 +1,17 @@
+import math
+
+m , n = map(int,input().split())
+
+board = [True for _ in range(n+1)]
+
+for i in range(2, int(math.sqrt(n))+1):
+    j = 2
+    while i*j <= n:
+        board[i*j] = False
+        j += 1
+
+for i in range(m, n+1):
+    if i == 1:
+        continue
+    if board[i]:
+        print(i)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1929번 소수 구하기] (https://www.acmicpc.net/problem/1929)

---

### 💡 문제에서 사용된 알고리즘

- 에라토스테네스의 체

---

### 📜 코드 설명

소수 구하기 중 자주 사용하는 에라토스테네스의 체를 이용해서 문제를 풀었다.

에라토스테네스의 체는 2의 배수, 3의 배수, 4의 배수 .... n제곱근의 배수까지 전체 데이터에 배수를 먼저 없애 소수만 남기는 방법이다.

문제를 풀기 위해 1은 소수가 아니므로 2부터 시작하여 n제곱근+1 까지 범위를 잡아 2*2, 2*3 ..... 2*j 가 n과 같거나 작을 때까지 while을 돌려 board 리스트를 False 시켜주었다. (board[i*j] = False)

그 이후 정답을 나타낼 때, m 부터 n까지 반복문을 통해 i가 1일 때는 continue로 건너뛰고, board[i] 가 True일 때, 즉 소수일 때만 출력하도록 만들었다.

---
