### PR TITLE
백준 1966 프린터 큐

### DIFF
--- a/hyeonwoo/백준 1966 프린터 큐.py
+++ b/hyeonwoo/백준 1966 프린터 큐.py
@@ -1,0 +1,33 @@
+from collections import deque
+import sys
+
+input = sys.stdin.readline
+
+t = int(input())
+
+for _ in range(t):
+    n, m = map(int, input().split())
+    queue = deque(map(int, input().split()))
+
+    queue_idx = deque([_ for _ in range(n)])
+
+    # 몇 번째로 인쇄되었는지 궁금한 문서
+    queue_idx[m] = "doc"
+
+    cnt = 0
+    while True:
+        # 현재 문서의 중요도가 가장 높다면
+        if queue[0] == max(queue):
+            cnt += 1
+
+            if queue_idx[0] == "doc":
+                print(cnt)
+                break
+
+            else:
+                queue.popleft()
+                queue_idx.popleft()
+
+        else:
+            queue.append(queue.popleft())
+            queue_idx.append(queue_idx.popleft())


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1966 프린터 큐](https://www.acmicpc.net/problem/1966)

---

### 💡 문제에서 사용된 알고리즘

- 자료 구조
- 큐

---

### 📜 코드 설명

- 문서의 중요도를 큐에 저장하고, 큐의 첫 번째 값과 큐의 최대값이 다르다면, 현재 문서보다 더 높은 중요도를 가진 문서가 있기 때문에 큐의 첫 번째 값을 빼서 큐의 마지막에 저장한다.
- 큐의 첫 번째 값과 큐의 최대값이 같다면, 첫 번째 값이 즁요도가 제일 높은 문서이기 때문에 큐에서 값을 뺀 후 `cnt` 값을 증가시킨다.
- 반복문을 통해 위 과정을 반복하고, 큐에서 뺀 값이 `m`번째 위치한 문서이면 `cnt` 값을 출력한다.
  - 이 때, 중요도가 같은 문서가 존재할 수 있기 때문에 단순히 큐의 인덱스만으로 비교하면 안된다.
  - 따라서 문서의 중요도를 큐에 저장할 때, 문서의 중요도의 순서를 인덱스로 가지는 또 다른 큐를 하나 더 만들어서 위 과정에서 큐를 빼거나 저장할 때, 인덱스가 저장된 큐 또한 같은 연산을 수행해서 문제가 요구하는 문서의 위치를 추적하면서 `cnt` 값을 출력한다.

---
