### PR TITLE
백준 2667 단지번호붙이기

### DIFF
--- a/byeongjoo/백준 2667 단지번호붙이기.py
+++ b/byeongjoo/백준 2667 단지번호붙이기.py
@@ -1,0 +1,46 @@
+"""
+hosu 변수를 단지로 읽어주시면 감사하겠습니다...
+"""
+
+from collections import deque
+
+dx = [0,0,1,-1]
+dy = [1,-1,0,0]
+n = int(input())
+q = deque()
+board=[]
+hosu = 0 # 단지 개수
+for _ in range(n):
+    board.append(list(map(int, input())))
+countList= [] # 각 단지마다 몇 채의 집이 있는지 개수 세기
+
+for i in range(n):
+    for j in range(n):
+        if board[i][j] == 0: # 보드 안에 0으로 되어있는 부분 및 BFS 통해 개수가 세어진 호수를 제거하기 위한 목적
+            continue
+
+        q.append((i,j))
+        board[i][j] = 0
+        count = 1 # 현재 단지의 집 1채 추가
+        hosu += 1 # 단지 카운트 증가
+        while q: #BFS
+            x, y = q.popleft()
+            for d in range(4):
+                nx = x + dx[d]
+                ny = y + dy[d]
+
+                if nx <0 or nx>= n or ny <0 or ny>=n:
+                    continue
+
+                if board[nx][ny] == 1: #만약 다음 집을 세지 않았다면
+                    board[nx][ny] = 0 # 세기 편하기 위해 다음 집을 0으로 만들어주기 (방문확인 목적)
+                    q.append((nx,ny)) # 다음 집을 queue에 삽입
+                    count += 1 # 현재 단지의 집 1 채를 더 추가
+
+        countList.append(count)
+
+countList.sort() # 정렬
+
+print(hosu)
+for i in countList:
+    print(i)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 2667번 단지번호붙이기] (https://www.acmicpc.net/problem/2667)

---

### 💡 문제에서 사용된 알고리즘

BFS

---

### 📜 코드 설명

단지와 각 단지에 속한 집의 개수를 세는 문제이다.

BFS로 풀기 위해 처음 아이디어로 각 시작점이 되는 위치를 잡아야되나라고 생각을 하였지만, 그러기엔 1 집합의 위치들이 하나로 모두 합쳐져있는 게 아니라 각각 섹션 별로 나누어져 있어 불가능하다고 생각하였다.

그렇기에 예전에 풀었던 백준 1926번 그림(https://www.acmicpc.net/problem/1926) 문제처럼 일단 초기 queue에 삽입할 때 쓸 조건문과 BFS를 합쳐버리는 형식으로 풀었다.

이중 for문을 이용하여 일단 board의 값이 0이면 뛰어넘어버리고, 1이라면 큐에 i, j값을 삽입한 후, 삽입된 board[i][j] 는 0으로 처리를 하였다. (** 현 코드에서 board[?][?] = 0 으로 되어있는 부분들은 모두 방문처리를 위한 목적이다. => 이유 : 방문처리를 하지 않는다면 bfs 돌다가 다음에 잡히는 값으로도 쓰일 수 있기 때문이다.)
단지 집을 세는 카운트를 1로 만들어주고, 단지는 1씩 추가해주었다.

그 후 BFS 를 돌리며, 만약 board[nx][ny]가 1, 즉 방문하지 않았다면 방문처리를 한 후 단지의 집 카운트를 추가해주었다.

bfs가 끝날 때마다 각 단지의 집을 세는 count를 countList에 삽입해주었다.

마지막으로 출력을 위해 countList를 정렬해주었다.

---
