### PR TITLE
백준 15829 Hashing

### DIFF
--- a/hyeonwoo/백준 15829 Hashing.py
+++ b/hyeonwoo/백준 15829 Hashing.py
@@ -1,0 +1,13 @@
+import sys
+
+input = sys.stdin.readline
+
+l = int(input())
+arr = list(map(str, input().rstrip()))
+m = 1234567891
+
+result = 0
+for i in range(l):
+    result += (ord(arr[i]) - 96) * (31**i)
+
+print(result % m)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 15829 Hashing](https://www.acmicpc.net/problem/15829)

---

### 💡 문제에서 사용된 알고리즘

- 문자열
- 해싱

---

### 📜 코드 설명

- 문자열에 고유 번호를 부여하기 위해 `ord()` 함수를 이용했고, 알파벳 소문자 `a`의 아스키 코드값이 `97`이기 때문에 문자열의 아스키 코드값에서 `96`만큼 빼주어 `1`부터 시작하는 고유 번호를 부여했다.

---
