### PR TITLE
백준 10026번 적록색약

### DIFF
--- a/byeongjoo/백준 10026 적록색약.py
+++ b/byeongjoo/백준 10026 적록색약.py
@@ -1,0 +1,57 @@
+from collections import deque
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+board= []
+dx = [0,0,1,-1]
+dy = [1,-1,0,0]
+
+for _ in range(n):
+    board.append(list(input()))
+
+def bfs(visit, q): # BFS 함수
+    while q:
+        x, y = q.popleft()
+
+        for d in range(4):
+            nx = x + dx[d]
+            ny = y + dy[d]
+
+            if nx < 0 or nx >= n or ny < 0 or ny >= n :
+                continue
+
+            if visit[nx][ny] == 1 or board[x][y] != board[nx][ny]: # 이미 방문을 했거나 board 색깔이 바뀌는 지점이라면
+                continue
+
+            visit[nx][ny] = 1
+            q.append((nx, ny))
+
+
+def redGreen(isP): # 적록색약 구분 함수. 안에 bfs 넣을 것
+    count = 0
+    q = deque()
+    visit = [[0] * n for _ in range(n)]
+    if isP == 1: # 적록색약이라면 board 초록-빨강 합쳐주기
+        for i in range(n):
+            for j in range(n):
+                if board[i][j] == "G":
+                    board[i][j] = "R"
+
+    for i in range(n):
+        for j in range(n):
+            if visit[i][j] != 0:
+                continue
+            q.append((i,j))
+            visit[i][j] = 1
+            bfs(visit, q)
+            count+=1
+
+    return count
+
+
+
+
+print(redGreen(0), end= " ") # 적록 색약이 아닌 사람.
+print(redGreen(1)) # 적록 색약인 사람.


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 10026번 적록색약] (https://www.acmicpc.net/problem/10026)

---

### 💡 문제에서 사용된 알고리즘

BFS

---

### 📜 코드 설명

def bfs 함수는 bfs 관련 함수이다. 일반적인 bfs 구현을 사용했으며, 두번째 조건문이 이번 문제의 킥포인트 중 하나인데 이미 방문처리가 되었거나 (visit[nx][ny] == 1) 보드 상에서 색깔이 바뀌는 지점일 때 (board[nx][ny] == board[x][y]) 는 다음 이동을 건너뛰어야 한다.

def redGreen 함수는 메인이 되는 함수이며, 적록색약을 구분 하는 함수이다. 그러기에 isP라는 파라미터를 줘서 isP가 1이라면 적록색약이므로 빨강-초록을 같은 색으로 만들어주고, 0이라면 같은 색 만드는 과정을 스킵한다. 이 함수 내에서 초깃값을 잡아주는 이유는 적록색약이 아닌 사람과 적록색약인 사람은 같은 보드 내에서 각각 BFS를 사용해야 하므로 초기값을 초기화해준 것이다. 그렇기에 방문배열, 큐, 영역을 세는 count를 초기화해주었다.

출력은 redGreen(0) , redGreen(1) 순으로 출력 해주었다.

** 개인적 생각
적록색약이 아닌 사람이 먼저 값으로 들어오고, 적록색약인 사람이 다음 값으로 들어왔기에 board의 초기값은 망가지지 않고 유지되었다. 하지만 이 적록색약 사람의 순서가 바뀌었다면 board 또한 초기화해주어야 하지 않았을까 싶다.

---
