### PR TITLE
백준 1654 랜선 자르기

### DIFF
--- a/hyeonwoo/백준 1654 랜선 자르기.py
+++ b/hyeonwoo/백준 1654 랜선 자르기.py
@@ -1,0 +1,48 @@
+import sys
+
+input = sys.stdin.readline
+
+
+# 입력 받은 랜선의 길이로 케이블들을 잘랐을 때, 만들 수 있는 랜선의 개수를 반환하는 함수
+def cut_cable(new_cable):
+    result = 0
+
+    for cable in cables:
+        result += cable // new_cable
+
+    return result
+
+
+# 입력 받은 랜선의 길이로 n개 이상의 랜선을 가져갈 수 있는지 확인하는 함수
+def check_cables(cable):
+    if cut_cable(cable) >= n:
+        return True
+
+    if cut_cable(cable) < n:
+        return False
+
+
+# k: 이미 가지고 있는 랜선의 개수
+# n: 필요한 랜선의 개수
+k, n = map(int, input().split())
+
+# 이미 가지고 있는 랜선들의 길이
+cables = [int(input()) for _ in range(k)]
+
+# n개를 무조건 만들 수 있는 랜선의 최소 길이
+start = 1
+
+# 랜선을 무조건 만들 수 없는 랜선의 최소 길이
+end = max(cables) + 1
+
+# start와 end의 범위를 좁혀가면서
+# mid(랜선의 길이) 값으로 랜선을 n개 이상 가져갈 수 있는지 확인
+while start + 1 < end:
+    mid = (start + end) // 2
+
+    if check_cables(mid):
+        start = mid
+    else:
+        end = mid
+
+print(start)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1654 랜선 자르기](https://www.acmicpc.net/problem/1654)

---

### 💡 문제에서 사용된 알고리즘

- 이진 탐색
- 매개변수 탐색

---

### 📜 코드 설명

- 조건을 만족하는 최대값을 구하기 위해 **매개변수 탐색**을 이용했다. 매개변수 탐색은 내부적으로 이진 탐색을 사용한다.
- 문제는 최소 `n`개 이상의 랜선을 가져갈 수 있게끔 자를 수 있는 랜선의 최대 길이를 요구하고 있다.
  - ***`n`개를 무조건 만들 수 있는*** **랜선의 최소 길이**는 1이다.
  - ***랜선을 무조건 만들 수 없는*** **랜선의 최소 길이**는 이미 가지고 있는 케이블 중 최대 길이를 가진 케이블보다 `1`만큼 긴 케이블이다.
- ***`n`개를 무조건 만들 수 있는 값***을 `start` 변수에 대입
***랜선을 무조건 만들 수 없는 값***을 `end` 변수에 대입
  - 여기서 **이진 탐색**을 이용하여 `start`와 `end`의 범위를 절반씩 좁혀가며, `mid` 값(**랜선의 길이**)으로 랜선을 `n`개 이상 가져갈 수 있는지 확인한다.
  - 랜선의 길이로 잘랐을 때,  랜선을 `n`개 이상 가져갈 수 있으면 `start` 변수에 랜선의 길이를 대입하여 범위를 줄인다.
  - 랜선의 길이로 잘랐을 때, 랜선을 `n`개 이상 가져갈 수 없으면 `end` 변수에 랜선의 길이를 대입한다.
  - 반복문을 통해 범위를 좁혀가며, `1`부터 `주어진 랜선의 최대 길이 + 1`까지 탐색을 완료했다면 반복문을 종료한다.
- 랜선의 길이로 `n`개 이상의 랜선을 가져갈 수 있는지는 `check_cables(cable)` 함수로 확인한다.
  - 이 때, 랜선의 길이로 이미 가지고 있는 랜선들을 잘랐을 때, 만들 수 있는 개수를 `cut_cable(new_cable)` 함수로 반환한다.

---
