### PR TITLE
백준 5427번 불

### DIFF
--- a/byeongjoo/백준 5427 불.py
+++ b/byeongjoo/백준 5427 불.py
@@ -1,0 +1,78 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+t = int(input())
+
+dx = [0,0,1,-1]
+dy = [1,-1,0,0]
+
+for _ in range(t):
+    w, h = map(int, input().split())
+    board = []
+
+    #불
+    q1 = deque()
+    visit1 = [[0] * w for _ in range(h)]
+    #상근이
+    q2 = deque()
+    visit2 = [[0] * w for _ in range(h)]
+
+
+    for _ in range(h):
+        board.append(list(input()))
+
+    for i in range(h):
+        for j in range(w):
+            if board[i][j] == "*":
+                q1.append((i,j))
+                visit1[i][j] = 1
+
+            if board[i][j] == "@":
+                q2.append((i,j))
+                visit2[i][j] = 1
+
+    #불 bfs
+    while q1:
+        x, y = q1.popleft()
+
+        for d in range(4):
+            nx = x + dx[d]
+            ny = y + dy[d]
+
+            if nx < 0 or nx >=h or ny < 0 or ny >=w:
+                continue
+
+            if board[nx][ny] == "#" or visit1[nx][ny] != 0 :
+                continue
+
+            visit1[nx][ny] = visit1[x][y] + 1
+            q1.append((nx, ny))
+
+    impossible = True # impossible 내보내기
+    doubleBreak = False # while 까지 탈출하기 위해 boolean 선언
+    #상근이 bfs
+    while q2:
+        if doubleBreak:
+            break
+        x, y = q2.popleft()
+
+        for d in range(4):
+            nx = x + dx[d]
+            ny = y + dy[d]
+
+            if nx < 0 or nx >=h or ny < 0 or ny >=w:
+                print(visit2[x][y])
+                doubleBreak = True
+                impossible = False
+                break
+
+            if board[nx][ny] == "#" or visit2[nx][ny] != 0:
+                continue
+
+            if visit1[nx][ny] != 0 and visit1[nx][ny] <= visit2[x][y]+1:
+                continue
+
+            visit2[nx][ny] = visit2[x][y] +1
+            q2.append((nx,ny))
+    if impossible:
+        print("IMPOSSIBLE")


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 5427번 불] (https://www.acmicpc.net/problem/5427)

---

### 💡 문제에서 사용된 알고리즘

BFS

---

### 📜 코드 설명

백준 4179번 불! (https://www.acmicpc.net/problem/4179) 의 응용 버전 문제.

이번에는 테스트 개수가 주어지고, board 모양이 다 달라지므로 테스트 개수를 for문으로 하는 반복문 안에 모든 변수들을 초기화 시켜주어야 한다. 그렇기에 본인은 불 bfs 위해 q1, visit1, 상근이 bfs 위해 q2, visit2 를 초기화를 계속 시켜주었다. board 도 케이스마다 다르므로 초기화를 꼭 시켜줘야한다.

이중 for문을 사용하여 board 안에서 *(불) 과 @(상근이) 의 위치를 찾아 각각의 큐에 삽입 및 visit 배열에 방문처리를 해주었다. (visit[i][j] = 1)

이번 bfs 는 이동거리를 재는 문제이기에 bfs 를 돌릴 때 거리를 나타낼 수 있도록 둘 다 visit[nx][ny] = visit[x][y] +1 처럼 처음 위치에서 멀어질수록 1씩 늘려가는 형태로 지정하였다.

먼저 불 bfs는 일반적인 bfs 처럼 사용하여 visit1 리스트의 값을 채워 넣기 위해 사용하였다.

그 후 상근이 bfs 를 하기 전, impossible을 찍을 수 있도록 하기 위해 boolean 형태로 impossible 변수를 만들고, 상근이 bfs 내에 정답을 찍고 while까지 벗어나기 위해 doubleBreak 변수를 선언해주었다. (✨이 게 백준 4179번 불! 에서 응용된 것이라고 생각한다.)

상근이 bfs를 돌면서 nx, ny 가 board 크기 바깥으로 나갔다면 탈출하는 것이기에 탈출을 시켜줬다.

중요한 건 상근이 bfs 조건문 중 세 번째 조건문인 if visit1[nx][ny] != 0 and visit1[nx][ny] <= visit2[x][y]+1 이다. 불이 붙은 지점이지만 불이 붙기까지 거리 보다 상근이의 거리가 더 크거나 같다면 이미 불이 나있는 곳이기에 지나갈 수 없다. 한 지점이 만약 불의 거리가 3이고, 상근이가 그 지점에 도착할 때 3이나 4라고 해보면 이미 상근이보다 불이 먼저 빠르게 붙어있었거나 붙는 순간이기에 문제가 된다. ('불이 옮겨진 칸 또는 이제 불이 붙으려는 칸으로 이동할 수 없다' 라고 지문에 쓰여 있다.)

만약 bfs가 다 돌았으며, impossible이 아직도 True로 잡혀있다면 "IMPOSSIBLE" 을 찍어주면 된다.
---
