### PR TITLE
백준 1629 곱셈

### DIFF
--- a/byeongjoo/백준 1629 곱셈.py
+++ b/byeongjoo/백준 1629 곱셈.py
@@ -1,0 +1,14 @@
+a, b, c = map(int, input().split())
+
+def recur(a, b, c):
+    if b == 1: # base condition
+        return a % c
+
+    val = recur(a, b//2, c) # a^(b/2) % c
+    result = val * val % c # result = a^b % c
+    if b % 2 == 0: # 지수가 짝수 일 경우
+        return result # a^(2*b*0.5) % c
+    elif b % 2 == 1:
+        return result * a % c # a^(2*b*0.5 +1) % c
+
+print(recur(a, b, c))


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 1629번 곱셈] (https://www.acmicpc.net/problem/1629)

---

### 💡 문제에서 사용된 알고리즘

재귀

---

### 📜 코드 설명

재귀를 연습해보기 위해 푼 문제.

이 문제는 시간 복잡도가 약 5천 번 ~ 1억 5천 번(최대)을 넘기면 안되지만 이미 한 변수당 최대값이 1억 5천을 넘겨버렸기에 반복문을 사용해서 풀 수 없다고 보였다. 

재귀를 이용해서 공간 메모리를 많이 잡아먹더라도 재귀로 풀면 반복문을 사용하는 것보다 시간복잡도를 줄일 수 있다. (물론 때에 따라 다르다.)

재귀를 사용하기 위해 일단 base condition을 잡아주었다. base condition이란 재귀의 끝 점이라고 보면 된다. 마지막으로 찍고 쭈~욱 리턴을 시킬 곳. base condition으로 지수가 1일 경우는 a % c 만 해도 나머지값이 나오므로 base condition은 1로 잡아두었다.

일단 이 문제에서는 지수를 2로 나누는 식으로 계산을 했다. 지수가 1 아니면 0처럼 모든 각 홀수지수와 짝수지수의 나머지 값은 똑같기 때문이다.

recur 재귀를 도는 것을 식으로 나타내면 a^(b/2) % c 라고 나타낼 수 있다.
그후 result = val * val % c 를 해서 a^b % c 형태로 만들어 준다.
이제 지수가 짝수인지 홀수 인지 판별을 통해 지수인 경우는 result 상태를 return 해주면 되며, 홀수인 경우에는 지수를 2n+1 형태로 만들어주어야 하니 a를 한 번 더 곱한다.
---
