### PR TITLE
백준 11729 하노이 탑 이동 순서

### DIFF
--- a/byeongjoo/백준 11729 하노이 탑 이동 순서.py
+++ b/byeongjoo/백준 11729 하노이 탑 이동 순서.py
@@ -1,0 +1,23 @@
+import sys
+sys.setrecursionlimit(10000) # 파이썬 재귀 리밋 뚫기
+
+def hanoi(n, a, b): # recursive
+    if n == 1 : # base condition - 제일 꼭대기 원판
+        print(a, b)
+        return
+
+    hanoi(n-1, a, 6-a-b) # n-1개의 원판을 시작 막대기에서 6-a-b 막대기로 옮기기
+    print(a, b) # 옮긴 원판 찍기
+    hanoi(n-1, 6-a-b, b) # 6-a-b 막대기에서 끝 막대기로 옮기기
+
+n = int(input())
+print(2**n -1)
+"""
+원판 k개를 옮기기 위해 A번 이동이 필요.
+
+원판 k+1개를 옮길 때 k 개의 원판을 빈곳을 옮길 때 A번, k+1번 원판을 옮길 때 1번,
+k개의 원판을 다시 빈곳에서 목적지로 옮길 때 A 번 필요하므로 2A+1 번의 이동이 필요.
+
+초항이 1이 되기에, 일반항은 2^k - 1 .
+"""
+hanoi(n, 1, 3)


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 11729 하노이 탑 이동 순서] (https://www.acmicpc.net/problem/11729)

---

### 💡 문제에서 사용된 알고리즘

재귀

---

### 📜 코드 설명
하노이탑은 시작 막대기에서 끝막대기로 모든 원판을 이동시키는데, 밑원판은 윗 원판 위에 놔둘 수 없고 시작과 끝 막대기 사이에 중간 막대기 n개를 이용해 푸는 게임이다.

예를 들어 3개의 막대기와 n개의 원판이 있다치면, 시작점 막대기에서 n-1개의 원판을 중간 막대기로 옮긴 후, n번 원판을 끝막대기로 이동 후 중간 막대기의 n-1개의 막대기를 끝막대기에 올려주면 되는것이다.


1. 재귀함수 만들기
- base condition 잡기
재귀를 끝낼 시점을 잡기 위해 n == 1일 때 return을 통해 재귀를 끝내기로 했다.

- 재귀 돌리기
재귀를 끝내기 위해선 n을 계속해서 깎아주어야 하고, 문제에선 원판 1개씩 옮기는 것이니 n-1을 베이스로 잡고 간다. 처음엔 시작막대기(a)에서 중간막대기(6-a-b)로 옮기고 옮긴 원판이 어디 막대기에서 어느 막대기로 옮겨졌는지 찍은 후(print a, b) 옮긴 중간막대기(6-a-b) 에서 끝막대기(b)로 옮겨주면 된다.
*여기서 왜 6-a-b를 했는지 궁금할 수가 있는데 6은 막대기 번호의 총합이다.(1+2+3)

2. 옮긴 횟수
원판 k개를 옮기기 위해 A번 이동이 필요하다. 
원판 k+1개를 옮길 때 k 개의 원판을 빈곳을 옮길 때 A번, k+1번 원판을 옮길 때 1번, k개의 원판을 다시 빈곳에서 목적지로 옮길 때 A 번 필요하므로 2A+1 번의 이동이 필요하다.
초항이 1이 되기에, 일반항은 2^k - 1 이므로 파이썬으로 나타내면 2**k - 1을 출력하면 된다.
---
