### PR TITLE
Baekjoon_13023_ABCDE

### DIFF
--- a/sollyj/Baekjoon_13023_ABCDE.java
+++ b/sollyj/Baekjoon_13023_ABCDE.java
@@ -1,0 +1,63 @@
+// Baekjoon_13023_ABCDE
+package sollyj;
+
+import java.io.*;
+import java.util.*;
+
+public class Baekjoon_13023_ABCDE {
+    public static boolean visited[];   // 방문 기록 배열
+    public static ArrayList<Integer>[] A;   // 인접리스트
+    public static boolean arrive = false;   // 도착했는지 안했는지 depth가 5이상이면 true
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        // visited 배열 초기화
+        visited = new boolean[N];
+
+        // 사람수만큼 인접리스트 초기화
+        A = new ArrayList[N];
+        for(int i=0; i<N; i++) {
+            A[i] = new ArrayList<Integer>();
+        }
+
+        // 인접리스트에 값 넣어주기
+        for(int i=0; i<M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            A[a].add(b);
+            A[b].add(a);    // 양방향 그래프
+        }
+
+        // 깊이우선탐색을 하며 깊이를 카운트 한다
+        for(int i=0; i<N; i++) {
+            DFS(i, 1);
+            if(arrive)  break;
+        }
+
+        if(arrive)  System.out.println("1");
+        else    System.out.println("0");
+    }
+
+    private static void DFS(int now, int depth) {
+        if(depth >= 5 || arrive) {
+            arrive = true;
+            return;
+        }
+
+        visited[now] = true;
+
+        for(int k : A[now]) {   // 인접 노드들을 탐색(깊이 우선 탐색)
+            if(!visited[k]) {
+                DFS(k, depth+1);
+            }
+        }
+        visited[now] = false;
+    }
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 13023번 ABCDE](https://www.acmicpc.net/problem/13023)

---

### 💡 문제에서 사용된 알고리즘

- 탐색(DFS)

---

### 📜 코드 설명

- [백준_11724_연결요소의개수](https://github.com/Coding-Test-Study-Group/Coding-Test-Study/pull/125) 와 알고리즘은 같다.
- 좀 더 생각해봐야하는 점은
1. depth 전역 선언
    처음에 depth(깊이)를 전역에 선언해서 계속 오답이 났었다.
    전역에 선언하면 안되는 이유는 예제입력3 같은 경우다.
    사람수 0~5까지 돌면서 0 - 1 - 0(중단), 0 - 2 - 0(중단), ... 이 된다.
    depth를 전역에 선언했으므로 누적되어 계속 +되어 5이상이 돼버려 오답 발생
    따라서, 한 루프때만 depth가 쓰일수 있도록 해야한다.
2. visited[now]를 다시 false해줘야 하는것
    예를들어 A[0]에서 arrive 못했다면 A[1]을 순회해야하는데 A[0] 인접리스트에 1이 있어서 visited했다면 A[1]은 순회 못하게 된다.
    따라서 A[i]에서 arrive 못했다면 visited[i] = false해줘서 다음 인접리스트에서 i를 순회할 수 있게 해야한다.
---
