### PR TITLE
백준 3053 택시 기하학

### DIFF
--- a/hyeonwoo/백준 3053 택시 기하학.py
+++ b/hyeonwoo/백준 3053 택시 기하학.py
@@ -1,0 +1,9 @@
+import math
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+
+print(n * n * math.pi)
+print(2 * n * n)


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 3053 택시 기하학](https://www.acmicpc.net/problem/3053)

---

### 💡 문제에서 사용된 알고리즘

- 수학

---

### 📜 코드 설명

- 유클리드 기하학에서 원의 넓이는 `반지름 * 반지름 * 원주율`로 구한다.
- 택시 기하학에서 원은 마름모 꼴의 정사각형이다.
  - 따라서, 택시 기하학에서 원의 넓이는 `2 * 반지름 * 반지름`으로 구할 수 있다.

---
