### PR TITLE
백준 1074번 Z

### DIFF
--- a/byeongjoo/백준 1074 Z.py
+++ b/byeongjoo/백준 1074 Z.py
@@ -1,0 +1,35 @@
+import sys
+sys.setrecursionlimit(10000)
+cnt = 0 # 위치 값
+def recur(n, r, c):
+    global cnt
+    if n == 0: # base condition
+        return cnt
+
+    line = 2**(n-1) # 사각형의 한 변의 길이의 반
+
+    if r < line and c < line : # 행, 열이 특정 사각형의 변 길이의 반보다 모두 작을 때
+        recur(n - 1, r, c)
+        return cnt
+
+    elif r < line and c >= line : # 행은 작고, 열은 크거나 같을 때
+        recur(n - 1, r, c - line)
+        cnt += line * line # 사각형 1개 추가
+        return cnt
+
+    elif r >= line and c < line: # 행은 크거나 같고, 열은 작을 때
+        recur(n - 1, r - line, c)
+        cnt += 2 * (line * line) # 사각형 2개 추가
+        return cnt
+
+    else: # 행, 열 모두 크거나 같을 때
+        recur(n - 1, r - line, c - line)
+        cnt += 3 * (line * line) # 사각형 3개 추가
+        return cnt
+
+
+
+
+
+n, r, c = map(int, input().split())
+print(recur(n, r, c))


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 1074번 Z] (https://www.acmicpc.net/problem/1074)

---

### 💡 문제에서 사용된 알고리즘

재귀

---

### 📜 코드 설명

재귀를 하기 위해 한 사각형을 사분면으로 나누어 구하게 했다.

사분면을 나눌 때 면 위치를 구분짓기 위해 사각형의 한 변의 절반을 기준으로 잡았다. 물론 2^n * 2^n 크기로 정사각형이 커지므로 한 변의 절반은 2**(n-1) 이 된다.

1사분면은 행과 열이 절반보다 작으면 되고, 2사분면은 행은 작고 열은 크거나 같으면 되고, 3사분면은 행은 크거나 같고 열은 작고, 4사분면은 행과 열이 크거나 같아야 한다.

2사분면부터는 사각형의 넓이를 더해주는 식으로 구해주어, 특정 행 열의 cnt 누적해줘서 return 으로 제출했다.
2사분면은 사각형 1개, 3사분면은 사각형 2개, 4사분면은 사각형 3개를 더해주면 된다고 생각했다.

---
