### PR TITLE
Baekjoon_1167_트리의지름

### DIFF
--- a/sollyj/Baekjoon_1167_트리의지름.java
+++ b/sollyj/Baekjoon_1167_트리의지름.java
@@ -1,0 +1,90 @@
+// Baekjoon_1167_트리의지름
+package sollyj;
+
+import java.util.*;
+import java.io.*;
+
+public class Baekjoon_1167_트리의지름 {
+    public static boolean[] visited;
+    public static int[] distance;
+    public static ArrayList<Edge>[] A;
+
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int V = Integer.parseInt(br.readLine());
+
+        // 전역에 선언한 변수들 초기화
+        visited = new boolean[V+1];
+        distance = new int[V+1];
+        
+        // 인접리스트 초기화
+        A = new ArrayList[V+1];
+        for(int i=1; i<=V; i++) {
+            A[i] = new ArrayList<Edge>();
+        }
+
+        // 인접리스트에 데이터 저장
+        for(int i=1; i<=V; i++) {
+            st = new StringTokenizer(br.readLine());
+            int k = Integer.parseInt(st.nextToken());
+
+            while(true) {
+                int node = Integer.parseInt(st.nextToken());
+                if(node == -1)  break;
+                
+                int distance = Integer.parseInt(st.nextToken());
+                A[k].add(new Edge(node, distance));
+            }
+        }
+
+        BFS(1);
+
+        int max = 1;
+        // distance 배열에서 가장 큰 값으로 다시 시작점 설정
+        for(int i=2; i<=V; i++) {
+            if(distance[i] > distance[max]) 
+                max = i;
+        }
+
+        visited = new boolean[V+1];
+        distance = new int[V+1];
+        BFS(max);   // 새로운 시작점으로 다시 실행해서 distance배열 채우기
+        
+        // distance배열 오름차순 정렬 후 마지막 값 출력
+        Arrays.sort(distance);
+        System.out.println(distance[V]);
+    }
+
+    private static void BFS(int node) {
+        Queue<Integer> queue = new LinkedList<Integer>();
+
+        queue.add(node);
+        visited[node] = true;
+
+        while(!queue.isEmpty()) {
+            int newNode = queue.poll();
+
+            for(Edge instance : A[newNode]) {
+                int instanceNode = instance.node;
+                int instanceDist = instance.distance;
+
+                if(!visited[instanceNode]) {
+                    visited[instanceNode] = true;
+                    queue.add(instanceNode);
+                    distance[instanceNode] = distance[newNode] + instanceDist;   // 현재 노드와 instance의 노드는 연결되어있으므로 instance의 distance를 더해준다.
+                }
+            }
+        }
+    }
+}
+
+class Edge {
+    int node, distance;
+
+    public Edge(int node, int distance) {
+        this.node = node;
+        this.distance = distance;
+    }
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1167번 트리의지름](https://www.acmicpc.net/problem/1167)

---

### 💡 문제에서 사용된 알고리즘

- 탐색(BFS)

---

### 📜 코드 설명

- **이 문제를 DFS가 아닌 BFS로 풀어야하는 이유**
예를 들어, 노드3은 노드1과 노드4와 연결되어있는거지, 노드1과 노드4가 연결돼있다고 볼 수는 없다.
만약 DFS로 탐색해서 distance를 구하면 노드3-노드1-노드4의 distance를 구하는 것이 되어버린다.
따라서 이 문제는 너비우선탐색을 써야한다.
(예제입력은 우연찮게 DFS, BFS 결과가 똑같았다.)

- distance배열에서 가장 큰 값으로 다시 시작점 설정해 BFS실행
이 부분을 안해서 계속 오답이 나서 결국 답을 보았다(...)
처음에 임의의 노드(1)로 탐색을 해서 나온 distance배열은 _임의의 노드로부터의 거리_이다.
따라서 이게 답이라고 볼 수 없으므로, 임의의 노드에서 제일 먼 노드에서 다시 탐색을 해야한다.
---
