### PR TITLE
백준 1780 종이의 개수

### DIFF
--- a/byeongjoo/백준 1780 종이의 개수.py
+++ b/byeongjoo/백준 1780 종이의 개수.py
@@ -1,0 +1,50 @@
+import sys
+
+sys.setrecursionlimit(10000) # 재귀 뚫어주기
+input = sys.stdin.readline
+n = int(input())
+minus_sum = 0 # -1의 개수
+zero_sum = 0 # 0의 개수
+plus_sum = 0 # 1의 개수
+board = []
+for _ in range(n):
+    board.append(list(input().split()))
+
+def recur(x, y, n):
+
+    global minus_sum, zero_sum, plus_sum
+    target = board[x][y] #3^n * 3^n 종이의 좌측 상단을 타켓으로 잡기
+    flag = True # 3^n * 3^n 종이를 하나로 취급할지 안할지에 대한 flag
+
+    for i in range(x, x+n):
+        for j in range(y, y+n):
+            if board[i][j] != target: # 한 종이 내에서 이미 숫자가 다르다면
+                flag = False
+                break
+        if not flag: # 2중 for문 탈출
+            break
+
+    if flag == True: # 3^n * 3^n 이 모두 같은 크기일 때 , 하나하나의 요소
+        if int(target) == 1:
+            plus_sum += 1
+        elif int(target) == 0:
+            zero_sum += 1
+        elif int(target) == -1:
+            minus_sum += 1
+        return
+
+    offset = n // 3 # offset 크기 분할하기
+    for i in range(3):
+        for j in range(3):
+            recur(x+offset*i, y+offset*j, offset) # 재귀.
+            """
+                 (x,y)           (x,y+offset)            (x,y+2*offset)
+            (x+offset, y)    (x+offset, y+offset)    (x+offset, y+2*offset)
+            (x+2*offset, y) (x+2*offset, y+offset)   (x+2*offset, y+2*offset)
+            """
+
+
+recur(0, 0, n)
+print(minus_sum)
+print(zero_sum)
+print(plus_sum)


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 1780번 종이의 개수] (https://www.acmicpc.net/problem/1780)

---

### 💡 문제에서 사용된 알고리즘

재귀, 분할정복

---

### 📜 코드 설명

종이는 3^n * 3^n의 형태이며, 최소 종이의 크기는 1 * 1 이다. 
종이는 계속해서 9등분 형태로 나타내지며, 각 행과 열의 크기 차이는 3^n만큼 차이가 나게 된다.

크기 차이를 offset이라고 잡고, 행과 열을 x , y 로 나타냈을 때 좌표로 나타낸다면
                 (x,y)           (x,y+offset)            (x,y+2*offset)
            (x+offset, y)    (x+offset, y+offset)    (x+offset, y+2*offset)
            (x+2*offset, y) (x+2*offset, y+offset)   (x+2*offset, y+2*offset)

이런 형태가 된다.

일단 3^n * 3^n 종이가 모두 같은 수라면 종이를 9등분하지 말고 하나의 수로 나타내어 합계에 1을 추가해야되기에, target과 flag를 잡아야 된다.
target은 한 종이가 같은 수인지 체크하기 위해 사용되는 변수이며, flag 또한 같은 수인지 체크를 하기 위한 변수 및 각 숫자의 합에 가산을 위한 조건문의 condition이 될 것이다.

윗 이중 반복문은 각 종이의 위치 및 크기만큼 반복을 돌려 같은 수로만 이루어져있는지 아니면 다른 수로 구성되어 있는지 확인을 하기 위한 반복문이다.

반복문을 통해 flag 상태가 변해 false가 됬다면 합계에 접근하면 안되고, false 가 true가 유지되었다면 3^n * 3^n 크기의 종이가 같은 수로만 이루어져있다는 것을 알 수 있기에 합계에 접근을 한다.

그 이후 분할정복을 위해 n의 크기를 3으로 나누어 준다. 

이후 위에 좌표처럼 나타내기 위해 이중 for문을 이용해 재귀의 파라미터 모습을 만들어서 재귀를 돌린다.

---
