### PR TITLE
백준 1992 쿼드트리

### DIFF
--- a/byeongjoo/백준 1992 쿼드트리.py
+++ b/byeongjoo/백준 1992 쿼드트리.py
@@ -1,0 +1,29 @@
+n = int(input())
+
+board = []
+ans = []
+for _ in range(n):
+    board.append(list(input()))
+
+def recur(x, y, n):
+    global ans # 전역변수 만들기
+    target = board[x][y] # 타겟 만들기
+    for i in range(x, x+n):
+        for j in range(y, y+n):
+            if target != board[i][j]: # 만약 타겟과 보드의 요소가 다르다면 보드 4분할
+                offset = n // 2 # 분할정복을 위해 offset을 2로 나눔
+                ans.append("(") # 문제의 목적에 맞게 작은 크기로 잘라 괄호 안에 만들어주기
+                recur(x, y, offset) # (x, y)
+                recur(x, y+offset, offset) # (x, y+offset)
+                recur(x+offset, y, offset) # (x+offset , y)
+                recur(x+offset, y+offset, offset) # (x+offset, y+offset)
+                ans.append(")")
+                return
+
+    ans.append(target) # n*n 크기라면 ans 리스트에 추가
+
+recur(0,0,n)
+
+answer = "".join(map(str,ans)) # 문자열로 만들어주기
+
+print(answer)


### PR DESCRIPTION
### 📖 풀이한 문제

[백준 1992번 쿼드트리](https://www.acmicpc.net/problem/1992)

---

### 💡 문제에서 사용된 알고리즘

재귀, 분할정복

---

### 📜 코드 설명

분할정복을 사용해서 풀어야 되는 문제.

이 보드도 1/2 크기로 계속 잘라서
|||
|:---:|:---:|
|1|2|
|3|4|

순으로 나열 했을 때, 1->2->3->4 순으로 움직여야한다.

1/2 크기로 자르기 위해 offset 은 base condition 이 되는 1로 가까워져야 한다.

이후
|||
|:---:|:---:|
|(x,y)|(x,y+offset)|
|(x+offset,y)|(x+offset, y+offset)|

형식으로 재귀를 돌린다.
재귀를 돌리기전 '(' 을 하고, 사분면을 다 재귀를 했다면 ')'을 한다.

target 과 board가 일치한다면 분할을 할 필요 없이 정답에 나타낼 ans 리스트에 현재 값을 집어 넣는다.

마지막으로 ans리스트를 문자열로 만든 answer을 출력하면 된다.

---
