### PR TITLE
Baekjoon_2178_미로

### DIFF
--- a/sollyj/Baekjoon_2178_미로.java
+++ b/sollyj/Baekjoon_2178_미로.java
@@ -1,0 +1,66 @@
+// Baekjoon_2178_미로
+package sollyj;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Baekjoon_2178_미로 {
+    public static void main(String[] args) throws NumberFormatException, IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        char[][] miro = new char[N][M];
+        for(int i=0; i<N; i++) {
+            String str = br.readLine();
+            for(int j=0; j<M; j++) {
+                miro[i][j] = str.charAt(j);
+            }
+        }
+
+        Queue<Where> queue = new LinkedList<>();
+        int[][] dist = new int[N][M];   // 방문한 곳에 거리를 누적해서 +1할 배열
+        // 여기서는 하, 우 방향으로만 가므로 하, 우 순서를 먼저
+        int[] sx = {1, 0, -1, 0};   // 하, 우, 상, 좌 탐색하기 위한 x좌표(행)
+        int[] sy = {0, 1, 0, -1};   // 하, 우, 상, 좌 탐색하기 위한 y좌표(열)
+
+        queue.offer(new Where(0, 0));   // (0,0)부터 시작
+        dist[0][0] = 1;
+
+        while (!queue.isEmpty()) {
+            Where p = queue.poll();
+
+            for(int i=0; i<4; i++) {
+                int nx = p.x + sx[i];
+                int ny = p.y + sy[i];
+
+                if (nx >= 0 && nx < N && ny >= 0 && ny < M) {   // 좌표 유효성 검사
+                    if (miro[nx][ny] != '0' && dist[nx][ny] == 0) {   // 갈수 있는 칸 검사
+                        queue.offer(new Where(nx, ny));
+                        dist[nx][ny] = dist[p.x][p.y] + 1;   // (nx,ny)칸까지 거리 계산
+                    }
+                }
+            }
+        }
+
+        System.out.println(dist[N-1][M-1]);
+    }
+}
+
+// 패키지안에 Point클래스가 있어서 중복이 안된다.
+class Where {
+    int x;
+    int y;
+
+    Where(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+}
+


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 2178번 미로](https://www.acmicpc.net/problem/2178)

---

### 💡 문제에서 사용된 알고리즘

- 탐색(BFS)
_DFS보다 BFS가 적합한 이유는 목적지까지 가는 짧은 시간을 구해야하는것이기 때문에 해당 깊이(여기서는 행)에서 갈수있는 노드탐색을 마친 후 다음 깊이로 넘어가야하기 때문이다._

---

### 📜 코드 설명

- 필요한 변수
N(행), M(열)
miro(2차원배열)
dist(2차원배열): 방문한 곳에 거리를 누적해서 +1할 배열
하, 우, 상, 좌 탐색할 x, y좌표 배열 (하, 우방향으로 가므로 하, 우를 먼저 탐색)
queue

- 일반적인 BFS알고리즘과 똑같다. (0, 0)부터 시작하므로 큐에 넣고
- 방문했다는 의미가 곧 dist++와 같기때문에 dist에 누적하여 +1해준다.
- 좌표 유효성(미로를 넘어가진 않는지, 벽에 부딪히진 않는지) 검사와 갈 수 있는칸 검사를 한 후 큐에 넣어주고 또 dist에 누적하여 +1해준다.
- 그렇게 해서 최종적으로 dist[N-1][M-1]을 출력

---
