### PR TITLE
백준 1931번 회의실 배정

### DIFF
--- a/kkkwp/백준 1931번 회의실 배정.kts
+++ b/kkkwp/백준 1931번 회의실 배정.kts
@@ -1,0 +1,26 @@
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+data class Meeting(var start: Int, var end: Int)
+
+fun main() = with(BufferedReader(InputStreamReader(System.`in`))) {
+    var n = readln().toInt()
+    val meetings = mutableListOf<Meeting>()
+
+    repeat(n) {
+        var (start, end) = readln().split(' ').map { it.toInt() }
+        meetings.add(Meeting(start, end))
+    }
+
+    meetings.sortWith(compareBy({ it.end }, { it.start }))
+
+    var answer = 1
+    var now = meetings[0].end
+    for (i in 1 until n) {
+        if (meetings[i].start >= now) {
+            answer++
+            now = meetings[i].end
+        }
+    }
+    print(answer)
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1931번 회의실 배정](https://www.acmicpc.net/problem/1931)

---

### 💡 문제에서 사용된 알고리즘

- 그리디

---

### 📜 코드 설명

- 회의가 끝났을 때(now) 지금으로부터 회의가 끝난 시간(end)이 가장 빠른 것을 선택했을 때 회의를 가장 많이 할 수 있다. 따라서 end를 기준으로 정렬 (1순위)
- 회의 시간이 (5, 6), (6, 6)일 때는 전자를 선택해야 회의를 한번 더 진행할 수 있다. 따라서 start를 기준으로 정렬하는 것도 필요(2순위)

---
