### PR TITLE
Baekjoon_1931_회의실배정

### DIFF
--- a/sollyj/Baekjoon_1931_회의실배정.java
+++ b/sollyj/Baekjoon_1931_회의실배정.java
@@ -1,0 +1,50 @@
+// Baekjoon_1931_회의실배정
+package sollyj;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+public class Baekjoon_1931_회의실배정 {
+	public static void main(String[] args) {
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(System.in))) {
+			StringTokenizer st;
+
+			int N = Integer.parseInt(br.readLine());
+
+			int[][] conference = new int[N][2];
+			for (int i = 0; i < N; i++) {
+				st = new StringTokenizer(br.readLine());
+				conference[i][0] = Integer.parseInt(st.nextToken());
+				conference[i][1] = Integer.parseInt(st.nextToken());
+			}
+
+			// 정렬 수행
+			Arrays.sort(conference, new Comparator<int[]>() {
+				@Override
+				public int compare(int[] o1, int[] o2) {
+					if (o1[1] == o2[1]) {    // 끝나는 시간이 같으면
+						return o1[0] - o2[0];    // 시작 시간이 빠른 순서대로 정렬
+					} else {
+						return o1[1] - o2[1];    // 끝나는 시간이 빠른 순서대로 정렬
+					}
+				}
+			});
+
+			int end = -1;
+			int count = 0;
+			for (int i = 0; i < N; i++) {
+				if (conference[i][0] >= end) {
+					count++;
+					end = conference[i][1];
+				}
+			}
+
+			System.out.println(count);
+		} catch (Exception e) {
+			System.out.println(e.getLocalizedMessage());
+		}
+	}
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 1931번 회의실배정](https://www.acmicpc.net/problem/1931)

---

### 💡 문제에서 사용된 알고리즘

- 그리디

---

### 📜 코드 설명

- 연속으로 회의를 배정하려면 일단 회의 끝나는 시간을 기준으로 오름차순 정렬해 배열에 저장해야한다.
- 만약, 회의 끝나는 시간이 같다면 회의 시작 시간을 기준으로 오름차순 정렬한다.
- 정렬이 완료된 배열을 가지고 겹치지 않는 회의수를 카운트한다.

---
