### PR TITLE
프로그래머스 크기가 작은 부분 문자열

### DIFF
--- a/taejun/programmers/크기가작은부분문자열.java
+++ b/taejun/programmers/크기가작은부분문자열.java
@@ -1,0 +1,21 @@
+package taejun.programmers;
+
+class Solution {
+    public int solution(String t, String p) {
+        
+        int answer = 0;
+        int len = p.length();
+        long result = 0;
+        long target = Long.parseLong(p);
+
+        for(int i=0; i<t.length(); i++) {
+            if(i+len <= t.length()) {
+                result = Long.parseLong(t.substring(i, i+len));
+                if(result <= target) answer++;
+            }
+        }
+
+        System.out.println(answer);
+        return answer;
+    }
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [프로그래머스 크기가 작은 부분 문자열](https://school.programmers.co.kr/learn/courses/30/lessons/147355)
---

### 💡 문제에서 사용된 알고리즘

**부분 문자열**을 활용하는 것이 핵심이라고 느꼈습니다.

---

### 📜 코드 설명

이번 문제는 **부분 문자열**을 잘 활용하는 것이 핵심이다.

#### 아이디어 도출
- t에서 p의 길이만큼 잘라가며 부분 문자열(result)을 만든다.
- 위에서 만든 부분 문자열(result)가 p를 정수로 변환한 값보다 작거나 같은지를 확인하여 카운트를 세면 된다.

바로 코드를 작성해보자.

```java
int answer = 0;
int len = p.length();
int result = 0;
int target = Integer.parseInt(p);
```

먼저 t에서 만든 부분문자열이 p보다 작거나 같은지를 검증하여 카운트를 증가시킬 변수 answer를 초기화한다.
또한, p의 길이를 len이라는 변수에 저장하여 사용한다.
t에서 len만큼 잘라 만들 부분 문자열을 담을 result 변수를 만든다.
마지막으로 p를 정수로 담아 result와 비교하기 위한 target 변수를 만들면 된다.

```java
for(int i=0; i<t.length(); i++) {
    if(i+len <= t.length()) {
        result = Integer.parseInt(t.substring(i, i+len));
        if(result <= target) answer++;
    }
}
```

이제 t를 순회하면서 **p의 길이만큼 부분 문자열로 잘라서 정수로 변환한 값인 result과 p를 정수로 변환한 값인 target을 비교**해가며 카운트를 세면 된다.

> 여기서 t를 가지고 부분문자열을 만들 때, **i+len번째 문자열까지만 부분 문자열을 만들 수 있고 i+len+1번째 문자부터는 부분 문자열을 만들 수 없다는 점을 고려**하여 t를 순회하면서 부분문자열을 만들도록 해야 한다.

위와 같은 코드를 테스트케이스로 돌려보니 정상적으로 원하는 리턴값을 출력할 수 있었다.
그래서 바로 코드 제출을 했는데 일부 테스트케이스에서 런타임 에러가 발생하게 되었다.

#### 런타임 에러 해결
런타임 에러를 해결하기 위해 문제의 제한사항을 제대로 살피지 않은 것 같아 제한사항을 살펴보기로 하였다. 문제의 제한사항을 보면 아래와 같다.

- 1 ≤ p의 길이 ≤ 18
- p의 길이 ≤ t의 길이 ≤ 10,000
- t와 p는 숫자로만 이루어진 문자열이며, 0으로 시작하지 않습니다.

여기서 p의 길이와 t의 길이는 10000자 이하로 이루어지기 때문에 **int 값의 범위를 잘 고려했는지 확인**해야 한다.

int는 최대 10자리 수까지 밖에 표현할 수 없다. 반면에 **Long은 19자리까지 가능하기 때문에 `Integer.parseInt()`를 하는 과정에서 10자리 수를 넘어가는 경우에는 위처럼 런타임 에러가 발생**하게 되었던 것이다. 그래서 `Integer.parseInt()` 구문을 `Long.parseLong()`메서드로 변환해주도록 수정하여 제출하니 정상적으로 모든 테스트케이스를 통과할 수 있었다.

---
