### PR TITLE
백준 10811 바구니 뒤집기

### DIFF
--- a/taejun/baekjoon/10811.java
+++ b/taejun/baekjoon/10811.java
@@ -1,0 +1,49 @@
+package taejun.baekjoon;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int[] arr = new int[N];
+
+        for(int i=1; i<=N; i++) {
+            arr[i-1] = i;
+        }
+
+        for(int idx=0; idx<M; idx++) {
+            st = new StringTokenizer(br.readLine());
+            int i = Integer.parseInt(st.nextToken()) - 1;
+            int j = Integer.parseInt(st.nextToken()) - 1;
+
+            int[] tmp = new int[j-i+1];
+            int ridx = 0;
+            for(int r=j; r>=i; r--) {
+                tmp[ridx] = arr[r];
+                ridx++;
+            }
+            ridx = i;
+            for(int r : tmp) {
+                arr[ridx] = r;
+                ridx++;
+            }
+        }
+        for(int res : arr) {
+            bw.write(res + " ");
+        }
+               
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 10811번 바구니 뒤집기](https://www.acmicpc.net/problem/10811)

---

### 💡 문제에서 사용된 알고리즘

- 배열을 활용한 일반적인 구현 문제입니다.

---

### 📜 코드 설명

이번 `바구니 뒤집기` 문제는 배열의 일정 인덱스의 범위만큼을 담아둘 **임시 배열**을 활용하여 풀 수 있었다.

#### 아이디어 도출
N만큼의 길이를 가지는 원본 배열에서 주어지는 **i와 j만큼의 범위만큼을 잘라서 역순으로 담은 임시배열을 원본 배열에 덮어씌우는 방식**을 적용하였다.

- N과 M을 입력받고 N만큼의 길이를 가지는 배열을 생성한 뒤 1부터 N까지의 값으로 초기화한다.
- M만큼 반복하면서 i와 j를 입력받고, i와 j의 인덱스의 범위를 가지는 임시배열을 초기화 한다.
    - 여기서 임시배열의 크기는 `j-i+1`만큼을 가져야 한다.
- 원본 배열을 역순으로 임시배열에 담기 위해 j부터 i까지 역순으로 순회하면서 j-i의 인덱스 범위만큼 역순으로 임시배열에 담는다.
- 특정 범위만큼 역순으로 담긴 임시배열이 만들어졌다면 원본배열에 해당되는 범위에 임시배열의 값을 덮어씌운다.

아이디어를 말로 설명하자니 조금 복잡할 수 있다.
바로 코드를 작성해보자.

```java
int N = Integer.parseInt(st.nextToken());
int M = Integer.parseInt(st.nextToken());
int[] arr = new int[N];

for(int i=1; i<=N; i++) {
    arr[i-1] = i;
}
```

N과 M을 공백 기준으로 입력받은 후, N의 크기를 가지는 arr 배열을 선언하고 1부터 N까지의 값으로 초기화한다.

```java
for(int idx=0; idx<M; idx++) {
    st = new StringTokenizer(br.readLine());
    int i = Integer.parseInt(st.nextToken()) - 1;
    int j = Integer.parseInt(st.nextToken()) - 1;

    int[] tmp = new int[j-i+1];
    int ridx = 0;
    for(int r=j; r>=i; r--) {
        tmp[ridx] = arr[r];
        ridx++;
    }
    ridx = i;
    for(int r : tmp) {
        arr[ridx] = r;
        ridx++;
    }
}
```

M만큼 반복하면서 앞서 말했던 임시배열을 원본배열에 덮어씌우는 로직을 수행한다.

1. i부터 j까지의 범위를 역순으로 담을 임시배열 tmp를 생성한다. 이 떄, tmp는 `j-i+1`의 크기를 가져야 해당 범위만큼 역순으로 담을 수 있게 된다.
2. 원본배열의 역순으로 접근한 특정 범위의 값들을 tmp 배열에 순차적으로 담기 위해 **ridx라는 인덱스를 별도로 선언**한다.
3. 임시 배열에 원본배열의 특정 범위를 역순으로 삽입한다.
4. 원본배열에 특정 범위에 임시배열을 덮어씌우기 위해 **ridx를 i번째 인덱스 값으로 설정**한다.
5. 임시배열을 순회하면서 원본배열에 임시배열 값을 삽입하여 덮어씌운다.

---
