### PR TITLE
Programmers_콜라츠추측

### DIFF
--- a/sollyj/programmers/Programmers_콜라츠추측.java
+++ b/sollyj/programmers/Programmers_콜라츠추측.java
@@ -1,0 +1,32 @@
+package sollyj.programmers;
+
+public class Programmers_콜라츠추측 {
+	public static void main(String[] args) {
+		System.out.println(solution(626331));
+	}
+
+	private static int solution(int num) {
+		int answer = 0;
+		long n = num;    // 입력값이 크면 연산을 하다가 값이 커져 int 오버플로우 현상이 나타난다. 그래서 long형으로 임의로 바꿔주였다.
+
+		while (answer <= 500) {
+			if (n == 1) {
+				break;
+			}
+
+			if (n % 2 == 0) {
+				n /= 2;
+			} else {
+				n *= 3;
+				n += 1;
+			}
+
+			answer++;
+		}
+
+		if (answer > 500)
+			answer = -1;
+
+		return answer;
+	}
+}


### PR DESCRIPTION
### 📖 풀이한 문제

- [프로그래머스 콜라츠추측](https://school.programmers.co.kr/learn/courses/30/lessons/12943)

---

### 💡 문제에서 사용된 알고리즘

- 구현

---

### 📜 코드 설명

- 매개변수로 받은 num을 long형으로 바꿔주는 이유는
- `1 <= num < 8,000,000` 이기 때문에 num이 커지면 연산을 하다가 값이 커져 int `오버플로우` 현상이 나타난다.
- 그래서 임의로 long형으로 바꿔주였다.

---
