### PR TITLE
프로그래머스 연속 부분 수열 합의 개수

### DIFF
--- a/hyeonwoo/Python/프로그래머스/프로그래머스 연속 부분 수열 합의 개수.py
+++ b/hyeonwoo/Python/프로그래머스/프로그래머스 연속 부분 수열 합의 개수.py
@@ -1,0 +1,49 @@
+import unittest
+from itertools import cycle
+
+
+def solution(elements):
+    answer = 0
+
+    # 모든 부분 수열의 합의 개수를 저장할 집합
+    result = set()
+
+    # 수열의 전체 원소 개수
+    total_elements = len(elements)
+
+    # 전체 원소 개수 만큼 반복
+    for length in range(1, total_elements + 1):
+        # 원형 수열 생성
+        seq = cycle(elements)
+
+        # 원형 수열에서 모든 원소가 담긴 elemetns 리스트의 마지막 원소를 기준으로
+        # (현재 길이 - 1)만큼 늘어난 수열 생성
+        target_seq = [next(seq) for _ in range(total_elements + length - 1)]
+
+        # 타겟 수열의 전체 원소 개수
+        total_target_seq = len(target_seq)
+
+        # 타겟 수열의 원소 개수 만큼 반복
+        for i in range(total_target_seq):
+            # 현재 인덱스부터 현재 길이만큼의 부분 수열 생성
+            sub_seq = target_seq[i : i + length]
+
+            # 부분 수열의 길이가 현재 길이보다 작으면 반복문 종료
+            if len(sub_seq) < length:
+                break
+
+            # 현재 길이 만큼의 부분 수열 합 저장
+            result.add(sum(sub_seq))
+
+    answer = len(result)
+
+    return answer
+
+
+class TestSolution(unittest.TestCase):
+    def test_solution(self):
+        self.assertEqual(solution(elements=[7, 9, 1, 1, 4]), 18)
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()


### PR DESCRIPTION
### 📖 풀이한 문제

- [프로그래머스 연속 부분 수열 합의 개수](https://school.programmers.co.kr/learn/courses/30/lessons/131701)

---

### 💡 문제에서 사용된 알고리즘

- 구현

---

### 📜 코드 설명

- 문제는 `1`부터 `elements` 원소 개수만큼의 길이를 가진 연속 부분 수열의 합의 총 가짓수를 구하는 것이다.
  - 길이가 `1`인 연속 부분 수열을 구하기 위해서는 `[7, 9, 1, 1, 4]`의 배열에서 한 개씩 묶어서 더해주면 된다.
    - `[7] -> 합: 7`
    - `[9] -> 합: 9`
    - `[1] -> 합: 1`
    - `[1] -> 합: 1`
    - `[4] -> 합: 4`
    - 따라서, `[1, 4, 7, 9]` 총 `4`가지의 합을 구할 수 있다.
  - 길이가 `2`인 연속 부분 수열을 구하기 위해서는 `[7, 9, 1, 1, 4, 7]`의 배열에서 두 개씩 묶어서 더해주면 된다.
    - `[7, 9] -> 합: 16`
    - `[9, 1] -> 합: 10`
    - `[1, 1] -> 합: 2`
    - `[1, 4] -> 합: 5`
    - `[4, 7] -> 합: 11`
    - 따라서, `[2, 5, 10, 11, 16]` 총 `5`가지의 합을 구할 수 있다.
  - 길이가 `3`인 연속 부분 수열을 구하기 위해서는 `[7, 9, 1, 1, 4, 7, 9]`의 배열에서 세 개씩 묶어서 더해주면 된다.
    - `[7, 9, 1] -> 합: 17`
    - `[9, 1, 1] -> 합: 11`
    - `[1, 1, 4] -> 합: 6`
    - `[1, 4, 7] -> 합: 12`
    - `[4, 7, 9] -> 합: 20`
    - 따라서, `[6, 11, 12, 17, 20]` 총 `5`가지의 합을 구할 수 있다. 
- 위의 예시를 잘 보면 마지막 원소에서 처음 원소부터 `현재 길이 - 1`만큼의 원소를 추가해 준 후 `현재 길이`만큼 묶어주면 연속 부분 수열의 합을 구할 수 있다.
  - 먼저, 모든 `길이`에서의 연속 부분 수열의 합을 저장할 집합 자료형 `result` 변수를 생성해준다.
  - `elements`의 전체 원소 개수 만큼 반복문을 순회하여, `현재 길이`가 `1`부터 `전체 원소 개수`까지만큼의 연속 부분 수열을 구한다.
  - 원형 수열과 같이 `elements`의 마지막 원소 다음에 첫 번째 원소부터 다시 추가해주기 위해 `itertools` 라이브러리의 `cycle`을 이용하여 `elements`를 무한히 순회하는 배열 `seq`을 만들어준다.
  - 무한히 순회하는 원형 수열 `seq`를 이용해 `현재 길이 - 1`만큼의 수열 `target_seq`를 생성해준다.
    - 이 타겟 수열 `target_seq`의 총 원소 개수 만큼 반복문을 순회하여, `현재 길이`만큼의 연속 부분 수열 `sub_seq`를 구해준다.
      - 연속 부분 수열 `sub_seq`는 타겟 수열 `target_seq`에서 반복문의 `현재 인덱스`부터 `현재 길이`만큼 잘라서 구해준다.
        - 이 때, 슬라이싱 과정 중 `현재 길이`보다 작은 연속 부분 수열이 나올 수 있기 때문에 조건문을 통해 이를 예외 처리 해주었다.
          - ex) `target_seq = [7, 9, 1, 1, 4, 7]`, 총 원소 개수: `6`, 현재 길이는 `2`라고 가정
          - 타겟 수열 `target_seq`를 `현재 길이`만큼 묶어준다면 아래와 같은 결과를 얻을 수 있다.
          - 인덱스 `0`: `sub_seq = [7, 9]`
          - 인덱스 `1`: `sub_seq = [9, 1]`
          - 인덱스 `2`: `sub_seq = [1, 1]`
          - 인덱스 `3`: `sub_seq = [1, 4]`
          - 인덱스 `4`: `sub_seq = [4, 7]`
          - 인덱스 `5`: `sub_seq = [7]`
     - 위에서 구한 연속 부분 수열 `sub_seq`의 합을 `result` 변수에 저장해준다.
- 정답은 `result` 변수의 총 길이를 구하면, 모든 길이에서의 연속 부분 수열의 합을 구할 수 있다.

---

### 🔑 코드

```python
from itertools import cycle


def solution(elements):
    answer = 0

    # 모든 부분 수열의 합의 개수를 저장할 집합
    result = set()

    # 수열의 전체 원소 개수
    total_elements = len(elements)

    # 전체 원소 개수 만큼 반복
    for length in range(1, total_elements + 1):
        # 원형 수열 생성
        seq = cycle(elements)

        # 원형 수열에서 모든 원소가 담긴 elemetns 리스트의 마지막 원소를 기준으로
        # (현재 길이 - 1)만큼 늘어난 수열 생성
        target_seq = [next(seq) for _ in range(total_elements + length - 1)]

        # 타겟 수열의 전체 원소 개수
        total_target_seq = len(target_seq)

        # 타겟 수열의 원소 개수 만큼 반복
        for i in range(total_target_seq):
            # 현재 인덱스부터 현재 길이만큼의 부분 수열 생성
            sub_seq = target_seq[i : i + length]

            # 부분 수열의 길이가 현재 길이보다 작으면 반복문 종료
            if len(sub_seq) < length:
                break

            # 현재 길이 만큼의 부분 수열 합 저장
            result.add(sum(sub_seq))

    answer = len(result)

    return answer

```