### PR TITLE
백준 25556 포스택

### DIFF
--- a/hyeonwoo/Python/백준/백준 25556 포스택.py
+++ b/hyeonwoo/Python/백준/백준 25556 포스택.py
@@ -1,0 +1,25 @@
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+arr = list(map(int, input().split()))
+
+four_stack = {1: [0], 2: [0], 3: [0], 4: [0]}
+
+for i in range(n):
+    cnt = 1
+
+    while cnt < 5:
+        if arr[i] > four_stack[cnt][-1]:
+            four_stack[cnt].append(arr[i])
+            break
+        else:
+            cnt += 1
+
+    if cnt == 5:
+        print("NO")
+        break
+
+if cnt < 5:
+    print("YES")


### PR DESCRIPTION
### 📖 풀이한 문제

- [백준 25556번 포스택](https://www.acmicpc.net/problem/25556)

---

### 💡 문제에서 사용된 알고리즘

- 스택

---

### 📜 코드 설명

- 길이가 `N`인 순열의 첫 번째 원소부터 순서대로 4개의 스택 중 임의의 스택에 원소를 삽입하고, 순열의 모든 원소를 삽입했다면 4개의 스택 중 하나의 스택에서 수를 꺼내 새로운 순열(*오른쪽에서 왼쪽으로 나열*)을 만들어냈을 때, 새로운 순열이 오름차순이면 `YES`를 출력하고, 그렇지 않다면 `NO`를 출력하는 문제이다.
- 문제의 핵심은 스택을 이용해 문제 설명을 그대로 구현하는 것이 아닌 순열이 오름차순이 될 수 있게끔 스택에 원소를 넣고 뺄수 있는가를 판별하면 된다.

![image](https://github.com/Coding-Test-Study-Group/Coding-Test-Study/assets/70932170/d9606bf8-bc9b-40c4-9309-ee0a30282a56)

- 위 그림과 같이 스택에 넣으려는 원소가 스택에 담겨져 있는 숫자보다 크다면 스택에 삽입하고, 스택에 담겨져 있는 숫자보다 작다면 다른 스택에 삽입한다.

![image](https://github.com/Coding-Test-Study-Group/Coding-Test-Study/assets/70932170/fb7c505a-60ea-42ea-84ab-b43497e7842f)

- 위 그림은 스택에 넣으려는 원소가 스택에 담겨져 있는 숫자보다 작아 4개의 스택을 전부 사용했고, 넣으려는 원소가 4번째 스택의 마지막 원소보다 작아 추가적으로 담을 스택이 없다.
- 즉, 최종적으로 네 개의 스택에서 원소를 꺼내 새로운 순열을 만들 때 오름차순으로 만들 수 없다는 뜻이 된다.
- 이를 통해 입력받은 순열에서 네 개의 스택에 원소를 삽입할 때, 스택의 마지막 숫자를 비교해 원소가 크다면 스택에 삽입하고, 원소가 작다면 다른 스택에 삽입하고, 다른 스택에 삽입할 때 첫 번째, 두 번째, 세 번째, 네 번째 스택까지 확인했는데도 원소가 스택의 숫자보다 작다면 이 순열은 오름차순으로 만들 수 없는 순열이므로 `NO`를 출력한다.

---

### 🔑 코드

```python
import sys

input = sys.stdin.readline

n = int(input())
arr = list(map(int, input().split()))

four_stack = {1: [0], 2: [0], 3: [0], 4: [0]}

for i in range(n):
    cnt = 1

    while cnt < 5:
        if arr[i] > four_stack[cnt][-1]:
            four_stack[cnt].append(arr[i])
            break
        else:
            cnt += 1

    if cnt == 5:
        print("NO")
        break

if cnt < 5:
    print("YES")

```
